### PR TITLE
Avoiding Undefined array key "HTTP_HOST" warning in wpcli

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -183,7 +183,7 @@ class Plugin extends Abstract_Ilabs_Plugin {
 	}
 
 	public function woocommerce_block_support() {
-		$current_url   = "$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+		$current_url   = "$_SERVER[REQUEST_URI]";
 		$search_phrase = "order-received";
 		if ( strpos( $current_url, $search_phrase ) !== false ) {
 			return;


### PR DESCRIPTION
Avoiding warning when using with `wpcli`

```
PHP Warning:  Undefined array key "HTTP_HOST" in wp-content/plugins/platnosci-online-blue-media/src/Plugin.php on line 186
```