### PR TITLE
Fix current URL construction in woocommerce_block_support

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -183,7 +183,7 @@ class Plugin extends Abstract_Ilabs_Plugin {
 	}
 
 	public function woocommerce_block_support() {
-		$current_url   = "$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+		$current_url = ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '');
 		$search_phrase = "order-received";
 		if ( strpos( $current_url, $search_phrase ) !== false ) {
 			return;


### PR DESCRIPTION
Currently it causes a
> Warning: Undefined array key "HTTP_HOST"

Should solve https://github.com/bluepayment-plugin/autopay-payments/issues/8